### PR TITLE
[fix] Conditionally import CrossEncoder based on availability

### DIFF
--- a/korok/rerankers/rerankers.py
+++ b/korok/rerankers/rerankers.py
@@ -1,9 +1,10 @@
+import importlib
 from typing import List, Sequence, Tuple
-
-from sentence_transformers import CrossEncoder
-
+    
 
 class CrossEncoderReranker:
+    """A reranker class that uses a cross-encoder to rerank the results."""
+
     def __init__(self, model_name: str = "cross-encoder/ms-marco-MiniLM-L-6-v2", max_length: int = 512) -> None:
         """
         Initialize the CrossEncoder reranker.
@@ -11,8 +12,19 @@ class CrossEncoderReranker:
         :param model_name: The name of the pre-trained cross-encoder model.
         :param max_length: The maximum sequence length for the cross-encoder.
         """
+        if not self.is_available():
+            raise ImportError("sentence_transformers is not installed. Please install it using `pip install korok[rerankers]`.")
+        else:
+            global CrossEncoder
+            from sentence_transformers import CrossEncoder
+
         self.cross_encoder = CrossEncoder(model_name)
         self.cross_encoder.max_length = max_length
+    
+    @classmethod
+    def is_available(cls) -> bool:
+        """Check if the cross-encoder rerankeris available."""
+        return importlib.util.find_spec("sentence_transformers") is not None
 
     def __call__(
         self,


### PR DESCRIPTION
## TL;DR

Fixing the error where `CrossEncoder` was imported from `sentence_transformers` by defualt, even in cases when `korok[rerankers]` was not installed, causing `import korok` to error out.

![image](https://github.com/user-attachments/assets/ddbcf718-9000-4c08-9512-b93016661eb1)

## Autogen Summary
This pull request includes changes to the `CrossEncoderReranker` class in the `korok/rerankers/rerankers.py` file to improve error handling and modularity. The most important changes include adding a check for the availability of the `sentence_transformers` package and raising an appropriate error if it is not installed.

Improvements to error handling and modularity:

* Added an import statement for `importlib` to check for the availability of the `sentence_transformers` package.
* Added a docstring to the `CrossEncoderReranker` class to provide a brief description.
* Implemented a check in the `__init__` method to raise an `ImportError` if `sentence_transformers` is not installed, with instructions for installation.
* Added the `is_available` class method to check if the `sentence_transformers` package is available.