### PR TITLE
[FEAT] Implement hybrid search functionality with BM25 integration

### DIFF
--- a/korok/korok.py
+++ b/korok/korok.py
@@ -52,7 +52,7 @@ class Pipeline:
         texts: list[str],
         encoder: StaticModel,
         reranker: CrossEncoderReranker | None = None,
-        alpha: float = 0.5,
+        alpha: float = 1.0,
         **kwargs: Any,
     ) -> Pipeline:
         """

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -30,6 +30,8 @@ class Pipeline:
         :param reranker: The reranker used to rerank the results (optional).
         :param bm25: The bm25 index used for hybrid search (optional).   
         :param alpha: The alpha value for the hybrid search (optional).
+        :param corpus: The corpus used for bm25 search (optional).
+        
         """
         self.encoder = encoder
         self.vicinity = vicinity

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -170,7 +170,7 @@ class Pipeline:
         vectors = self.encoder.encode(texts, show_progressbar=True)
         results = self.vicinity.query(vectors, k)
 
-        # Do bm25 search if alpha > 0 and merge results
+        # Do bm25 search if alpha < 1 and merge results
         if self.bm25 is not None and self.alpha < 1.0:
             query_tokens = bm25s.tokenize(texts, stopwords="en")
             bm25_results = self.bm25.retrieve(query_tokens, k=k, corpus=self.corpus, return_as="tuple")

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -105,17 +105,17 @@ class Pipeline:
         denom = max_score - min_score
         numerator = scores - min_score
 
-        return numerator / denom
+        # Handle division by zero
+        result = np.divide(numerator, denom)
+        assert scores.shape == result.shape, \
+              ("Shape mismatch between scores and result",
+               f"scores shape: {scores.shape}, result shape: {result.shape}")
+        return result
 
     def _split_vicinity_results(self, results: List[List[Tuple[str, float]]]) -> Tuple[List[str], np.ndarray]:
         """Split the results from vector search into two lists."""
-        vicinity_docs = []
-        vicinity_scores = []
-        for result in results:
-            for doc, score in result:
-                vicinity_docs.append(doc)
-                vicinity_scores.append(score)
-        vicinity_scores = np.array(vicinity_scores)
+        vicinity_docs = [[doc for doc, _ in result] for result in results]
+        vicinity_scores = np.array([[score for _, score in result] for result in results])
         return (vicinity_docs, vicinity_scores)
 
     def _merge_results(

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -14,7 +14,7 @@ from korok.rerankers import CrossEncoderReranker
 
 @dataclass
 class Document:
-    text: str
+    text: str = None
     vicinity_score: float = 0.0
     bm25_score: float = 0.0
 

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -105,11 +105,8 @@ class Pipeline:
         denom = max_score - min_score
         numerator = scores - min_score
 
-        # Handle division by zero
-        result = np.divide(numerator, denom)
-        assert scores.shape == result.shape, \
-              ("Shape mismatch between scores and result",
-               f"scores shape: {scores.shape}, result shape: {result.shape}")
+        # Handle division by zero, zero if max == min, i.e. all scores are the same
+        result = np.divide(numerator, denom, out=scores, where=denom != 0)
         return result
 
     def _split_vicinity_results(self, results: List[List[Tuple[str, float]]]) -> Tuple[List[str], np.ndarray]:

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -151,9 +151,9 @@ class Pipeline:
         # Combine the docs and scores into a list of tuples
         results = []
         for i in range(len(vicinity_results)):
-            results.append([])
-            for key, value in scores_list[i].items():
-                results[i].append((key, value.combine_scores(self.alpha)))
+            # Get the combined scores
+            results.append([(key, value.combine_scores(self.alpha))
+                             for key, value in scores_list[i].items()])
 
             # Sort the scores
             results[i].sort(key=lambda x: x[1], reverse=True)

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -153,14 +153,13 @@ class Pipeline:
         results = []
         for i in range(len(vicinity_results)):
             # Get the combined scores
-            results.append([(key, value.combine_scores(self.alpha))
-                             for key, value in scores_list[i].items()])
-
+            result = [(key, value.combine_scores(self.alpha)) for key, value in scores_list[i].items()]
+            
             # Sort the scores
-            results[i].sort(key=lambda x: x[1], reverse=True)
+            result.sort(key=lambda x: x[1], reverse=True)
 
             # Take the top k results
-            results[i] = results[i][:k]
+            results.append(result[:k])
 
         return results
 

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+from importlib.util import find_spec
+from typing import TYPE_CHECKING, Any, List, Tuple
 
+import numpy as np
 from model2vec import StaticModel
 from vicinity import Backend, Metric, Vicinity
 
 from korok.rerankers import CrossEncoderReranker
 
+if TYPE_CHECKING:
+    import bm25s
 
 class Pipeline:
     def __init__(
@@ -14,6 +18,9 @@ class Pipeline:
         encoder: StaticModel,
         vicinity: Vicinity,
         reranker: CrossEncoderReranker | None = None,
+        bm25: "bm25s.BM25" | None = None,
+        alpha: float = 0.5,
+        corpus: list[str] | None = None,
     ) -> None:
         """
         Initialize a Pipeline instance.
@@ -21,10 +28,23 @@ class Pipeline:
         :param encoder: The encoder used to encode the items.
         :param vicinity: The vicinity object used to find nearest neighbors.
         :param reranker: The reranker used to rerank the results (optional).
+        :param bm25: The bm25 index used for hybrid search (optional).   
+        :param alpha: The alpha value for the hybrid search (optional).
         """
         self.encoder = encoder
         self.vicinity = vicinity
         self.reranker = reranker
+        self.bm25 = bm25
+        self.alpha = alpha
+        self.corpus = corpus
+
+        if self.alpha < 0.0 or self.alpha > 1.0:
+            raise ValueError("Alpha must be between 0 and 1")
+
+    @classmethod
+    def is_hybrid_available(cls) -> bool:
+        """Check if the hybrid search is available."""
+        return find_spec("bm25s") is not None
 
     @classmethod
     def fit(
@@ -32,6 +52,7 @@ class Pipeline:
         texts: list[str],
         encoder: StaticModel,
         reranker: CrossEncoderReranker | None = None,
+        alpha: float = 0.5,
         **kwargs: Any,
     ) -> Pipeline:
         """
@@ -40,6 +61,7 @@ class Pipeline:
         :param texts: The texts to fit the encoder to.
         :param encoder: The encoder to use.
         :param reranker: The reranker to use (optional).
+        :param alpha: The alpha value for the hybrid search (optional).
         :param **kwargs: Additional keyword arguments.
         :return: A Pipeline instance.
         """
@@ -51,8 +73,86 @@ class Pipeline:
             metric=Metric.COSINE,
             **kwargs,
         )
-        return cls(encoder=encoder, vicinity=vicinity, reranker=reranker)
 
+        # Add bm25s if alpha > 0
+        if cls.is_hybrid_available() and alpha < 1.0:
+            global bm25s
+            import bm25s
+            
+            bm25 = bm25s.BM25()
+            tokens = bm25s.tokenize(texts, stopwords="en")
+            bm25.index(tokens)
+        else:
+            bm25 = None
+
+        return cls(encoder=encoder, 
+                   vicinity=vicinity, 
+                   reranker=reranker, 
+                   bm25=bm25, 
+                   alpha=alpha,
+                   corpus=texts)
+    
+    def _normalize_scores(self, scores: np.ndarray) -> np.ndarray:
+        """Normalize the scores to be between 0 and 1."""
+        denom = np.max(scores, axis=-1).reshape(-1, 1) - np.min(scores, axis=-1).reshape(-1, 1)
+        numerator = scores - np.min(scores, axis=-1).reshape(-1, 1)
+        return numerator / denom
+    
+    def _split_vicinity_results(self, results: List[List[Tuple[str, float]]]) -> List[List[Tuple[str, float]]]:
+        """Split the results from vector search into two lists."""
+        vicinity_docs = []
+        vicinity_scores = []
+        for i in range(len(results)):
+            vicinity_docs.append([str(results[i][j][0]) for j in range(len(results[i]))])
+            vicinity_scores.append([results[i][j][1] for j in range(len(results[i]))])
+        vicinity_scores = np.array(vicinity_scores)
+        return vicinity_docs, vicinity_scores
+
+    def _merge_results(self,
+                       vicinity_results: List[List[Tuple[str, np.float64]]],
+                       bm25_results: Tuple[List[List[str]], np.ndarray], 
+                       k: int = 10) -> List[List[tuple[str, float]]]:
+        """Merge the results from vector search and bm25 search."""
+        # Initialize the scores list
+        scores_list = [{} for i in range(len(vicinity_results))]
+
+        # Split the results into docs and scores
+        vicinity_docs, vicinity_scores = self._split_vicinity_results(vicinity_results)
+        bm25_docs, bm25_scores = bm25_results
+
+        # convert bm25 docs to strings
+        bm25_docs = [[str(doc) for doc in doclist] for doclist in bm25_docs]
+
+        # Normalize the scores
+        vicinity_scores = self._normalize_scores(vicinity_scores)
+        bm25_scores = self._normalize_scores(bm25_scores)
+
+        # Combine the docs and scores into a dictionary (to account for mismatched docs)
+        for i in range(len(vicinity_results)):
+            for doc, score in zip(vicinity_docs[i], vicinity_scores[i]):
+                scores_list[i][doc] = {"vicinity": score, "bm25": 0}
+            
+            for doc, score in zip(bm25_docs[i], bm25_scores[i]):
+                if doc not in scores_list[i]:
+                    scores_list[i][doc] = {"vicinity": 0, "bm25": score}
+                else:
+                    scores_list[i][doc]["bm25"] = score
+        
+        # Combine the docs and scores into a list of tuples
+        results = []
+        for i in range(len(vicinity_results)):
+            results.append([])
+            for key, value in scores_list[i].items():
+                results[i].append((key, value['bm25'] * (1 - self.alpha) + value['vicinity'] * self.alpha))
+            
+            # Sort the scores
+            results[i].sort(key=lambda x: x[1], reverse=True)
+
+            # Take the top k results
+            results[i] = results[i][:k]
+        
+        return results
+        
     def query(
         self,
         texts: list[str],
@@ -66,10 +166,18 @@ class Pipeline:
         :return: For each item in the input, the num most similar items are returned in the form of
             (NAME, SIMILARITY) tuples.
         """
+        # Do vector search
         vectors = self.encoder.encode(texts, show_progressbar=True)
         results = self.vicinity.query(vectors, k)
+
+        # Do bm25 search if alpha > 0 and merge results
+        if self.bm25 is not None and self.alpha < 1.0:
+            query_tokens = bm25s.tokenize(texts, stopwords="en")
+            bm25_results = self.bm25.retrieve(query_tokens, k=k, corpus=self.corpus, return_as="tuple")
+            results = self._merge_results(results, bm25_results, k=k)
 
         # Apply reranker if available
         if self.reranker is not None:
             results = self.reranker(texts, results)
+
         return results

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -59,6 +59,7 @@ class Pipeline:
         encoder: StaticModel,
         reranker: CrossEncoderReranker | None = None,
         alpha: float = 1.0,
+        stopwords: str | List[str] = "en",
         **kwargs: Any,
     ) -> Pipeline:
         """
@@ -68,6 +69,7 @@ class Pipeline:
         :param encoder: The encoder to use.
         :param reranker: The reranker to use (optional).
         :param alpha: The alpha value for the hybrid search (optional).
+        :param stopwords: The stopwords to use for bm25 search (optional).
         :param **kwargs: Additional keyword arguments.
         :return: A Pipeline instance.
         """
@@ -86,7 +88,7 @@ class Pipeline:
             import bm25s
 
             bm25 = bm25s.BM25()
-            tokens = bm25s.tokenize(texts, stopwords="en")
+            tokens = bm25s.tokenize(texts, stopwords=stopwords)
             bm25.index(tokens)
         else:
             bm25 = None

--- a/korok/korok.py
+++ b/korok/korok.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, List, Tuple
 
@@ -125,7 +126,7 @@ class Pipeline:
     ) -> List[List[tuple[str, float]]]:
         """Merge the results from vector search and bm25 search."""
         # Initialize the scores list
-        scores_list = [{} for i in range(len(vicinity_results))]
+        scores_list = []
 
         # Split the results into docs and scores
         vicinity_docs, vicinity_scores = self._split_vicinity_results(vicinity_results)
@@ -140,14 +141,14 @@ class Pipeline:
 
         # Combine the docs and scores into a dictionary (to account for mismatched docs)
         for i in range(len(vicinity_results)):
+            scores_list.append(defaultdict(Document))
             for doc, score in zip(vicinity_docs[i], vicinity_scores[i]):
-                scores_list[i][doc] = Document(text=doc, vicinity_score=score)
+                scores_list[i][doc].text = doc
+                scores_list[i][doc].vicinity_score = score
 
             for doc, score in zip(bm25_docs[i], bm25_scores[i]):
-                if doc not in scores_list[i]:
-                    scores_list[i][doc] = Document(text=doc, bm25_score=score)
-                else:
-                    scores_list[i][doc].bm25_score = score
+                scores_list[i][doc].text = doc
+                scores_list[i][doc].bm25_score = score
 
         # Combine the docs and scores into a list of tuples
         results = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ requires-python = ">=3.10"
 dependencies = [
     "model2vec",
     "vicinity",
+    "sentence-transformers",
+    "transformers<4.47.0",
+    "bm25s"
 ]
 
 [build-system]
@@ -35,6 +38,7 @@ all = [
     "vicinity",
     "sentence-transformers",
     "transformers<4.47.0",
+    "bm25s",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,20 +26,6 @@ dev = [
     "pytest-coverage",
     "ruff",
 ]
-rerankers = [
-    "sentence-transformers",
-    "transformers<4.47.0",
-]
-hybrid = [
-    "bm25s",
-]
-all = [
-    "model2vec",
-    "vicinity",
-    "sentence-transformers",
-    "transformers<4.47.0",
-    "bm25s",
-]
 
 [tool.ruff]
 exclude = [".venv/"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,9 @@ rerankers = [
     "sentence-transformers",
     "transformers<4.47.0",
 ]
+hybrid = [
+    "bm25s",
+]
 all = [
     "model2vec",
     "vicinity",


### PR DESCRIPTION
## Description

Add support for hybrid search by adding BM25S index fitting and search. 

We first initialize the BM25S index in the `fit` fn, and then during retrieval, based on the value of `alpha` we decide to combine it with vector search. `alpha` is a common value deciding the strength of the respective scores, which affects how much weight each component receives. 

Given that it required major code for combining the values together, I created a separate function `_merge_results` with the process to normalize the scores for each of the components, weighted addition based on `alpha`, re-rank them by combined scores, trim based on `k` value, and then present. 

`alpha` by default is set to `1.0` which implies that hybrid search is disabled

Please let me know if anything else is needed. Happy to receive feedback. 😊

## Copilot Summary
This pull request introduces significant enhancements to the `Pipeline` class in the `korok/korok.py` file, focusing on enabling hybrid search by integrating BM25 with vector search. The changes include updates to the initialization, fitting, and querying processes, as well as the addition of utility methods for normalizing and merging search results.

Key changes include:

### Hybrid Search Integration:

* Added `bm25` and `alpha` parameters to the `Pipeline` class to support hybrid search. The `bm25` parameter allows for the inclusion of a BM25 index, while the `alpha` parameter controls the weighting between BM25 and vector search results.
* Implemented the `is_hybrid_available` class method to check for the availability of the BM25 module.
* Updated the `fit` method to initialize and index BM25 if hybrid search is enabled (`alpha < 1.0`).
* Modified the `query` method to perform BM25 search and merge results with vector search results when hybrid search is enabled.

### Utility Methods for Result Handling:

* Added `_normalize_scores` to normalize search scores between 0 and 1.
* Added `_split_vicinity_results` to separate vector search results into documents and scores.
* Added `_merge_results` to combine and rank results from vector search and BM25 search based on the provided `alpha` value.

### Dependency Management:

* Added a new dependency group `hybrid` in `pyproject.toml` to include the `bm25s` package required for hybrid search.